### PR TITLE
Add missing dependency echodata

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,7 +37,8 @@ Imports:
     stringr,
     reticulate (>= 1.24),
     basilisk,
-    basilisk.utils
+    basilisk.utils,
+    echodata
 Suggests:
     markdown,
     rmarkdown,


### PR DESCRIPTION
Discovered while troubleshooting https://github.com/RajLabMSSM/echofinemap/issues/7

Confirmed this was also caught by `R CMD check`:

https://github.com/RajLabMSSM/echoconda/actions/runs/3028422625/jobs/4873194999#step:23:48